### PR TITLE
feat:lang2voice (#3)

### DIFF
--- a/ovos_tts_plugin_edge_tts/__init__.py
+++ b/ovos_tts_plugin_edge_tts/__init__.py
@@ -170,7 +170,7 @@ VOICES = {'af-ZA': ['af-ZA-AdriNeural', 'af-ZA-WillemNeural'],
 
 class EdgeTTSPlugin(StreamingTTS):
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs, audio_ext="mp3")
         self.voice = self.config.get("voice", "en-US-AriaNeural")
         self.rate = self.config.get("rate", "+0%")  # use +0% for normal speed (100%)
 


### PR DESCRIPTION
was defaulting to "wav" but files are mp3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The audio output format for the Edge TTS plugin has been updated to default to MP3, enhancing compatibility and user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->